### PR TITLE
Added the ability to populate attributes with existing translations via ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ You can also pass options:
 	<p ng-i18next="[html:i18next]({lng:'de'})hello"></p>
 => translates ````hello```` in German (````de````) and compiles it to HTML code.
 
+### Passing Options + interpopulate ###
+You can also pass options that reference existing translations:
+
+Assuming translation file:
+
+```
+{
+	"super": "Super",
+	"superDuper": "__attribute__ Duper"
+}
+```
+
+	<p ng-i18next="[html:i18next]({attribute: 'i18n.t.super'})hello"></p>
+=> translates to the string ```Super Duper```
+
 ---------
 
 For more, see examples.

--- a/src/directive/directive.js
+++ b/src/directive/directive.js
@@ -50,6 +50,19 @@ angular.module('jm.i18next').directive('ngI18next', ['$rootScope', '$i18next', '
 
 				options = $parse(keys[0])();
 
+				//Check to see if any of the options need to be localized
+				for (var k in options) {
+
+					if (typeof options[k] === 'string' && options[k].indexOf('i18n.t.') > -1) {
+
+						var valToLocalize = options[k].split('i18n.t.')[1];
+
+						options[k] = i18n.t(valToLocalize);
+
+					}
+
+				}
+
 				strippedKey = keys[1];
 
 			}

--- a/test/unit/i18nextDirectiveSpec.js
+++ b/test/unit/i18nextDirectiveSpec.js
@@ -112,6 +112,13 @@ describe('jm.i18next - Directive', function () {
 			});
 		});
 
+		it('should interpopulate existing translation within an option', function () {
+			inject(function ($rootScope, $compile) {
+				var c = $compile('<p ng-i18next="[i18next]({name:\'i18n.t.woman\'})helloName"></p>')($rootScope).text();
+				expect(c).toEqual('Herzlich Willkommen, Frau!');
+			});
+		});
+
 	});
 
 	describe('using $scope', function () {


### PR DESCRIPTION
...directive by adding a new convention of referencing an existing translation with i18n.t.xxxxx where xxxxx is the translation you wish to use in a new translation.  A real world example of this, is if you have a translation for the word password and have error handling for the when that field isn't filled out.  Instead of translating the word 'password' multiple times your translation can now reference it.  Updated doc and tests to reflect changes.
