### PR TITLE
Only re-initialize i18next when options change

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -74,7 +74,9 @@ angular.module('jm.i18next').provider('$i18next', function () {
 
 			optionsObj = $i18nextTanslate.options;
 
-			init(optionsObj);
+			if (oldOptions !== newOptions) {
+				init(optionsObj);
+			}
 
 		}, true);
 


### PR DESCRIPTION
Angular seems to trigger the `$watch` on `$i18nextTanslate.options` mutliple times with the same value, which causes i18next to ge re-initialized unnecessarily.  This is especially bad when we dynamically load resources (it downloads the translation file multiple times).  

This change adds a small check to prevent re-initialization of i18next when given the same options.
