### PR TITLE
Compile only when necessary

### DIFF
--- a/src/directive/directive.js
+++ b/src/directive/directive.js
@@ -70,6 +70,11 @@ angular.module('jm.i18next').directive('ngI18next', ['$rootScope', '$i18next', '
 		if (attr === 'html') {
 
 			element.empty().append(string);
+			/*
+			 * Now compile the content of the element and bind the variables to
+			 * the scope
+			 */
+			$compile(element.contents())(scope);
 
 		} else if (attr === 'text') {
 
@@ -80,11 +85,6 @@ angular.module('jm.i18next').directive('ngI18next', ['$rootScope', '$i18next', '
 			element.attr(attr, string);
 
 		}
-		/*
-		 * Now compile the content of the element and bind the variables to
-		 * the scope
-		 */
-		$compile(element.contents())(scope);
 
 		if (!$rootScope.$$phase) {
 			$rootScope.$digest();


### PR DESCRIPTION
Compiling text makes angular create a useless "<span ng-scope/>" DOM node to enclose the text. This patch keeps the compilation behaviour for the only use case it is really needed for.
