### PR TITLE
fix(directive): fix directive's interpolation content

### DIFF
--- a/src/directive/directive.js
+++ b/src/directive/directive.js
@@ -163,7 +163,7 @@ angular.module('jm.i18next').directive('ngI18next', ['$rootScope', '$i18next', '
 				}
 
 				// interpolate is allowing to transform {{expr}} into text
-				var interpolation = $interpolate(element.text());
+				var interpolation = $interpolate(element.html());
 
 				scope.$watch(interpolation, observe);
 


### PR DESCRIPTION
Hi,

By working with Quentin's modifications (being able to put the directive as attribute, but without content value and get the translation key from the tag's content), I got an issue when passing options containing html to i18next:

``` html
<span ng-i18next>
  [html:i18next]({
    count: '<span class="red">{{myCount}}</span>'
  })my:key
</span>
```

with `my:key = __count__ elephants`

The fix is that `interpolate` should take the content of the element with `element.html()`, not `element.text()` that strips all tags that may be inside…

This design was motivated because in some languages, you will need to reverse `__count__` and `elephants`, but keep the styling around `__count__` and keep it outside the translation files.
Plus that the file is easier to read when the key is outside of the attribute (syntax highlighting, indent, keep small tags, may have many variables to pass to i18next…).
