### PR TITLE
honor defaultValue before i18next is available; add extra option 'defaul...

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -58,7 +58,8 @@ angular.module('jm.i18next').provider('$i18next', function () {
 
 			if (!t) {
 				translations[lng][key] = 'defaultValue' in options ? options.defaultValue :
-					'defaultLoadingValue' in options ? options.defaultLoadingValue : key;
+					'defaultValue' in globalOptions ? globalOptions.defaultValue :
+					'defaultLoadingValue' in globalOptions ? globalOptions.defaultLoadingValue : key;
 			} else if (!translations[lng][key] || hasOwnOptions) {
 				translations[lng][key] = t(key, options);
 			}


### PR DESCRIPTION
I have tried various combinations of `ng-bind`, `ng-bind-attr`, `ng-cloak`, `ng-i18next`, etc. to avoid displaying key names very briefly while i18next is still loading, but could never get to the point where the value wasn't actually injected into the DOM until the actual translation was available. This pull request introduces two minor changes that helped me solve the problem (or related problems).
1. Support `defaultValue` before `t(...)` is available
   - Seems fairly reasonable and straight-forward, and causes it to behave more like `t(...)`
2. Add option `defaultLoadingValue` that can be used before `t(...)` is available.
   - The reason for this is to prevent a flash of i18n key names inside templates while i18next is still loading, but not lose the functionality of displaying key names for untranslated strings as a developer help.
