### PR TITLE
remove blatant LIE from the README (oops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,6 @@ these special loading values will be used instead.
 	<p>{{'hello' | i18next:{'defaultLoadingValue':'Loading...'} }}</p>
 => displays "Loading..." until i18next is loaded, then translates `hello`
 
-	<p>{{'not-translated-welcome-key' | i18next:{'defaultLoadingValue':'Loading...', 'defaultValue':'Welcome!'} }}</p>
-=> displays "Loading..." until i18next is loaded, then translates `not-translated-welcome-key` with default of "Welcome!"
-if the key is not defined in your i18n file
-
 ---------
 
 # Contribute #


### PR DESCRIPTION
I realized at lunch that one of the examples I added to the README was completely inaccurate -- it would have been accurate if we checked for `defaultLoadingValue` first, but that is not the way it works currently.
