### PR TITLE
Dynamically load additional namespaces

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -119,6 +119,31 @@ angular.module('jm.i18next').provider('$i18next', function () {
 			return optionsChange(globalOptions, globalOptions);
 		};
 
+		$i18nextTanslate.loadNamespace = function (namespace) {
+            // Check, if i18n is initialized or already initializing
+		    if (!t) {
+
+		        if (i18nDeferred === undefined) {
+		            globalOptions.ns = globalOptions.ns || {};
+		            globalOptions.ns.namespaces = globalOptions.ns.namespaces || [];
+		            globalOptions.ns.namespaces.push(namespace);
+		            return optionsChange(globalOptions, globalOptions);
+		        } else {
+		            return i18nDeferred.promise.then(function () {
+		                $i18nextTanslate.loadNamespace(namespace);
+		            })
+		        }
+		    }
+
+
+		    var nsLoadDeferred = $q.defer();
+		    window.i18n.loadNamespace(namespace, function () {
+		        nsLoadDeferred.resolve();
+		    });
+
+		    return nsLoadDeferred.promise;
+		}
+
 		if (self.watchOptions) {
 		    $rootScope.$watch(function () { return $i18nextTanslate.options; }, function (newOptions, oldOptions) {
 		        // Check whether there are new options and whether the new options are different from the old options.

--- a/src/provider.js
+++ b/src/provider.js
@@ -15,11 +15,15 @@ angular.module('jm.i18next').provider('$i18next', function () {
 	self.options = {};
 
 	self.watchOptions = true;
-	self.$get = ['$rootScope', '$timeout', function ($rootScope, $timeout) {
+
+	self.$get = ['$rootScope', '$timeout', '$q', function ($rootScope, $timeout, $q) {
+	
+	    var i18nDeferred;
 
 		function init(options) {
 
 			if (window.i18n) {
+			    i18nDeferred = $q.defer();
 
 				window.i18n.init(options, function (localize) {
 
@@ -33,16 +37,20 @@ angular.module('jm.i18next').provider('$i18next', function () {
 
 					$rootScope.$broadcast('i18nextLanguageChange');
 
+					i18nDeferred.resolve();
 				});
+
+				return i18nDeferred.promise;
 
 			} else {
 
 				triesToLoadI18next++;
 				// only check 4 times for i18next
+
 				if (triesToLoadI18next < 5) {
 
 					$timeout(function () {
-						init(options);
+						return init(options);
 					}, 400);
 
 				} else {
@@ -58,7 +66,7 @@ angular.module('jm.i18next').provider('$i18next', function () {
 
 			globalOptions = newOptions;
 
-			init(globalOptions);
+			return init(globalOptions);
 
 		}
 
@@ -108,7 +116,7 @@ angular.module('jm.i18next').provider('$i18next', function () {
 		}
 
 		$i18nextTanslate.reInit = function () {
-			optionsChange(globalOptions, globalOptions);
+			return optionsChange(globalOptions, globalOptions);
 		};
 
 		if (self.watchOptions) {

--- a/src/provider.js
+++ b/src/provider.js
@@ -14,6 +14,7 @@ angular.module('jm.i18next').provider('$i18next', function () {
 
 	self.options = {};
 
+	self.watchOptions = true;
 	self.$get = ['$rootScope', '$timeout', function ($rootScope, $timeout) {
 
 		function init(options) {
@@ -100,20 +101,24 @@ angular.module('jm.i18next').provider('$i18next', function () {
 
 		$i18nextTanslate.options = self.options;
 
-		if (self.options !== globalOptions) {
+		if (self.watchOptions && self.options !== globalOptions) {
 			optionsChange(self.options, globalOptions);
+		} else {
+		    globalOptions = self.options;
 		}
 
 		$i18nextTanslate.reInit = function () {
 			optionsChange(globalOptions, globalOptions);
 		};
 
-		$rootScope.$watch(function () { return $i18nextTanslate.options; }, function (newOptions, oldOptions) {
-			// Check whether there are new options and whether the new options are different from the old options.
-			if (!!newOptions && oldOptions !== newOptions) {
-				optionsChange(newOptions, oldOptions);
-			}
-		}, true);
+		if (self.watchOptions) {
+		    $rootScope.$watch(function () { return $i18nextTanslate.options; }, function (newOptions, oldOptions) {
+		        // Check whether there are new options and whether the new options are different from the old options.
+		        if (!!newOptions && oldOptions !== newOptions) {
+		            optionsChange(newOptions, oldOptions);
+		        }
+		    }, true);
+		}
 
 		return $i18nextTanslate;
 


### PR DESCRIPTION
I wanted to dynamically load additional namespaces. 
Current version doesn't support that - if I add a namespace to ng-i18next options, it reinitializes the i18n, which means, that it reloads all namespaces... If I use window.i18next.loadNamespace() function, we get the same result, as window.i18n.loadNamespace(), changes the i18next options, which are by ref the same as ng-i18next options, which then triggers the reinitialization again.

To add the feature:
- I added the option to not watch options for changes
- added $q promises
- and added loadNamespace function.

My usage is now like this - set default options in any module config section:

	$i18nextProvider.options = defaultOptionsObject;	// without any namespaces
	$i18nextProvider.watchOptions = false;

In any controller or service...

	$i18next.loadNamespace('myNamespace').then(function() {
		console.log('Translation for myNamespace loaded');
	}

On first loadNamespace() call i18next will be initialized, subsequent calls will just load additional namespaces... so every namespace is now loaded exactly once and, we get a promise of loading...