### PR TITLE
fix(directive): fix bug with defaultValue

### DIFF
--- a/src/directive/directive.js
+++ b/src/directive/directive.js
@@ -129,7 +129,7 @@ angular.module('jm.i18next').directive('ngI18next', ['$i18next', '$compile', '$p
 		require: 'ngI18next',
 
 		link: function postLink(scope, element, attrs, ctrl) {
-			var translationValue;
+			var translationValue = '';
 
 			function observe(value) {
 				translationValue = value.replace(/^\s+|\s+$/g, ''); // RegEx removes whitespace


### PR DESCRIPTION
If `i18nextLanguageChange` event is broadcasted before `$observe` is triggered in the directive, then `localize()` was called with an undefined key which makes it fail.
