### PR TITLE
Do not pass language to the translate function

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -10,6 +10,7 @@ angular.module('jm.i18next').provider('$i18next', function () {
 		t = null,
 		translations = {},
 		globalOptions = null,
+		translateOptions = null,
 		triesToLoadI18next = 0;
 
 	self.options = {};
@@ -56,6 +57,8 @@ angular.module('jm.i18next').provider('$i18next', function () {
 			$i18nextTanslate.debugMsg.push(['i18next options changed:', oldOptions, newOptions]);
 
 			globalOptions = newOptions;
+			translateOptions = angular.copy(globalOptions);
+			delete translateOptions.lng;
 
 			init(globalOptions);
 
@@ -90,7 +93,7 @@ angular.module('jm.i18next').provider('$i18next', function () {
 
 		function $i18nextTanslate(key, options) {
 
-			var mergedOptions = !!options ? angular.extend({}, globalOptions, options) : globalOptions;
+			var mergedOptions = !!options ? angular.extend({}, translateOptions, options) : translateOptions;
 
 			translate(key, mergedOptions, !!options);
 


### PR DESCRIPTION
This fixes a corner case scenario we encountered on our project.

When changing language by doing `$i18next.options.lng = 'fr'` for example, the next AngularJS digest cycle will execute the different bindings with i18n filters. However, there is no way to ensure that the new translations are loaded before we hit the callback in $i18nextProvider.init() that defines the new `t()` function to use.

Since options.lng is set, i18next will see that we are trying to translate in another language, and that this language is not loaded yet. It will then try to load the language.

Since we are using a custom load function, we see at his time a huge number of calls on this function from i18next (corresponding to 2 * &lt;number of namespaces> * &lt;number of translated keys in the page>) that should actually wait for ng-i18next's init() method to be called and returned successfully.

By not passing the language when translating, i18next will translate in the language set by the current `t()` function during this digest cycle. When the init() method returns, its callback will initiate a new digest cycle, and translate the page into the newly set language.