### PR TITLE
Allow angular 1.3+

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,11 +3,11 @@
   "main": "./dist/ng-i18next.js",
   "version": "0.3.5",
   "dependencies": {
-    "angular": "^1.2",
+    "angular": ">=1.2",
     "i18next": "^1.7.4"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.20"
+    "angular-mocks": ">=1.2.20"
   },
   "ignore": [
     "bower_components",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "git://github.com/archer96/ng-i18next.git"
   },
   "devDependencies": {
+    "bower": "^1.3.7",
     "jshint-stylish": "^0.4.0",
     "karma": "^0.12.17",
     "karma-jasmine": "^0.1.5",
@@ -33,5 +34,10 @@
     "gulp-jasmine": "^0.2.0",
     "gulp-header": "^1.0.5",
     "gulp-rimraf": "^0.1.0"
+  },
+  "scripts": {
+    "postinstall": "node ./node_modules/bower/bin/bower install",
+    "postupdate": "node ./node_modules/bower/bin/bower update",
+    "test": "gulp test"
   }
 }


### PR DESCRIPTION
- Angular came out with the 1.3.0 version and the bower strings are not permitting the minor version change.
- Also added bower to the package.json and helpful scripts to make build environment setup a one-liner: 'npm install'
