### PR TITLE
Sanitize substitutions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,8 @@
   "version": "0.3.6",
   "dependencies": {
     "angular": ">=1.2",
-    "i18next": "^1.7.4"
+    "i18next": "^1.7.4",
+    "angular-sanitize": ">=1.2"
   },
   "devDependencies": {
     "angular-mocks": ">=1.2.20"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -90,6 +90,7 @@ gulp.task('karma', function() {
 	gulp.src([
 			'bower_components/angular/angular.js',
 			'bower_components/angular-mocks/angular-mocks.js',
+			'bower_components/angular-sanitize/angular-sanitize.js',
 			'bower_components/i18next/i18next.min.js',
 			'src/provider.js',
 			'src/{,*/}*.js',

--- a/src/directive/directive.js
+++ b/src/directive/directive.js
@@ -1,4 +1,4 @@
-angular.module('jm.i18next').directive('ngI18next', ['$i18next', '$compile', '$parse', '$interpolate', function ($i18next, $compile, $parse, $interpolate) {
+angular.module('jm.i18next').directive('ngI18next', ['$i18next', '$compile', '$parse', '$interpolate', '$sanitize', function ($i18next, $compile, $parse, $interpolate, $sanitize) {
 
 	'use strict';
 
@@ -68,6 +68,12 @@ angular.module('jm.i18next').directive('ngI18next', ['$i18next', '$compile', '$p
 			function render(i18nOptions) {
 				if (i18nOptions.sprintf) {
 					i18nOptions.postProcess = 'sprintf';
+				}
+
+				if (parsedKey.options.attr === 'html') {
+					angular.forEach(i18nOptions, function(value, key) {
+						i18nOptions[key] = $sanitize(value);
+					});
 				}
 
 				var string = $i18next(parsedKey.key, i18nOptions);

--- a/src/provider.js
+++ b/src/provider.js
@@ -1,4 +1,4 @@
-angular.module('jm.i18next', ['ng']);
+angular.module('jm.i18next', ['ng', 'ngSanitize']);
 angular.module('jm.i18next').provider('$i18next', function () {
 
 	'use strict';

--- a/test/unit/i18nextDirectiveSpec.js
+++ b/test/unit/i18nextDirectiveSpec.js
@@ -220,6 +220,13 @@ describe('Unit: jm.i18next - Directive', function () {
 			});
 		});
 
+		it('should translate "hello" into German and sanitize the substitution ("de-DE"; default language)', function () {
+			inject(function ($rootScope, $compile) {
+				var c = $compile('<p ng-i18next="[html:i18next]({name:\'<img src=1 onError=alert()>\'})helloNameHTML"></p>')($rootScope);
+				$rootScope.$apply();
+				expect(c.html()).toBe('<h1 class="ng-scope">Herzlich Willkommen, <img src="1">!</h1>');
+			});
+		});
 	});
 
 });


### PR DESCRIPTION
Use $sanitize (ngSanitize) to clean/sanitize substituted variables and remove the risk of Cross-Site-Scripting (XSS) issues.

If ng-i18next is used with variables in the key text and the source of those variables is itself user-supplied content then it's possible to inject a cross site scripting attack via carefully crafted content being substituted into the translated text.

This can be fixed by using $sanitize on the substituted variables if the translation is in 'html mode'.