### PR TITLE
check if init is not done

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -9,7 +9,7 @@ angular.module('jm.i18next').provider('$i18next', function () {
 		 */
 		t = null,
 		translations = {},
-		globalOptions = null,
+		globalOptions = {},
 		triesToLoadI18next = 0;
 
 	self.options = {};
@@ -125,7 +125,8 @@ angular.module('jm.i18next').provider('$i18next', function () {
 
 		$rootScope.$watch(function () { return $i18nextTanslate.options; }, function (newOptions, oldOptions) {
 			// Check whether there are new options and whether the new options are different from the old options.
-			if (!!newOptions && oldOptions !== newOptions) {
+			// Check if globalOptions
+			if (!!newOptions && (oldOptions !== newOptions || globalOptions!== newOptions)) {
 				optionsChange(newOptions, oldOptions);
 			}
 		}, true);


### PR DESCRIPTION
When options is change in .run step and not in  .config step, oldOptions and
newOptions are equals so ng-i18next will never init.

Testing globalOptions will allow first init even if options is change
in .run.

This is mandatory if you want to override i18next.CustomLoad with $http for unit testing.
In this case it's not possible to prepare options in config step because $http is not available.
If you want to setup options in .run step, init of i18next never occurs because first time angular give you oldOptions and newOptions. Testing newOptions vs globalOptions resolve this special case.

Regards