### PR TITLE
avoid auto load off i18next on startup

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -12,7 +12,7 @@ angular.module('jm.i18next').provider('$i18next', function () {
 		globalOptions = {},
 		triesToLoadI18next = 0;
 
-	self.options = {};
+	self.options = globalOptions;
 
 	self.$get = ['$rootScope', '$timeout', function ($rootScope, $timeout) {
 


### PR DESCRIPTION
Because of object comparaison on nb-i18next init, if we want avoid an autoload of i18next to control it programmaticaly this condition must be true

![image](https://cloud.githubusercontent.com/assets/937507/6201163/4488f300-b49a-11e4-8956-923dabafe2f0.png)
