### PR TITLE
Provider($i18nextTanslate): do shallow instead of deep copy

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -123,7 +123,7 @@ angular.module('jm.i18next').provider('$i18next', function () {
 			// https://github.com/i18next/i18next/blob/e47bdb4d5528c752499b0209d829fde4e1cc96e7/src/i18next.translate.js#L232
 			// Because of i18next read namespace from `options.ns`
 			if (!hasOwnNsOption && hasGlobalNsObj) {
-				defaultOptions = angular.copy(globalOptions);
+				defaultOptions = angular.extend({}, globalOptions);
 				defaultOptions.ns = defaultOptions.ns.defaultNs;
 			}
 


### PR DESCRIPTION
We discovered a performance problem in our application and found $i18nextTanslate to be the culprit. It makes a deep copy of the global options for every translation. In our application, the global options contain all translations (which is one of the supported ways to provide the translations). So every time the function is called, all translations get copied.

Since the copy is only made to overwrite the ns field, a shallow copy is sufficient and much faster.
