### PR TITLE
Fix pluralization when using directive to bind as html

### DIFF
--- a/src/directive/directive.js
+++ b/src/directive/directive.js
@@ -74,7 +74,9 @@ angular.module('jm.i18next').directive('ngI18next', ['$i18next', '$compile', '$p
 
 				if (parsedKey.options.attr === 'html') {
 					angular.forEach(i18nOptions, function(value, key) {
-						i18nOptions[key] = $sanitize(value);
+						var sanitized = $sanitize(value);
+						var numeric = Number(value);
+						i18nOptions[key] = sanitized == numeric ? numeric : sanitized; // jshint ignore:line
 					});
 				}
 

--- a/test/unit/i18nextDirectiveSpec.js
+++ b/test/unit/i18nextDirectiveSpec.js
@@ -126,20 +126,44 @@ describe('Unit: jm.i18next - Directive', function () {
 
 	describe('plurals', function () {
 
-		it('should use the single form', function () {
-			inject(function ($rootScope, $compile) {
-				var c = $compile('<p ng-i18next="[i18next]({count: 1})woman"></p>')($rootScope);
-				$rootScope.$apply();
-				expect(c.text()).toEqual('Frau');
+		describe('as text', function () {
+
+			it('should use the single form', function () {
+				inject(function ($rootScope, $compile) {
+					var c = $compile('<p ng-i18next="[i18next]({count: 1})woman"></p>')($rootScope);
+					$rootScope.$apply();
+					expect(c.text()).toEqual('Frau');
+				});
 			});
+
+			it('should use the plural form', function () {
+				inject(function ($rootScope, $compile) {
+					var c = $compile('<p ng-i18next="[i18next]({count: 5})woman"></p>')($rootScope);
+					$rootScope.$apply();
+					expect(c.text()).toEqual('Frauen');
+				});
+			});
+
 		});
 
-		it('should use the plural form', function () {
-			inject(function ($rootScope, $compile) {
-				var c = $compile('<p ng-i18next="[i18next]({count: 5})woman"></p>')($rootScope);
-				$rootScope.$apply();
-				expect(c.text()).toEqual('Frauen');
+		describe('as html', function () {
+
+			it('should use the single form', function () {
+				inject(function ($rootScope, $compile) {
+					var c = $compile('<p ng-i18next="[html:i18next]({count: 1})woman"></p>')($rootScope);
+					$rootScope.$apply();
+					expect(c.text()).toEqual('Frau');
+				});
 			});
+
+			it('should use the plural form', function () {
+				inject(function ($rootScope, $compile) {
+					var c = $compile('<p ng-i18next="[html:i18next]({count: 5})woman"></p>')($rootScope);
+					$rootScope.$apply();
+					expect(c.text()).toEqual('Frauen');
+				});
+			});
+
 		});
 
 	});


### PR DESCRIPTION
Binding the directive to HTML currently does not work with pluralization, and has been broken since `v0.4.2`. The bug is because `$sanitize` turns numbers into strings—`$sanitize(3)` becomes the string `"3"`. As a result, an object like `{count: 3}` becomes `{count: "3"}`, which i18next does not pluralize because the special `"count"` property is no longer a Number.

I added the `ignore:line` bit because a double-equal equality comparison is disallowed by the jshint rules but allows us to easily detect and fix this condition, whereas a triple-equal identity comparison does not.