### PR TITLE
Use karma directly for tests. Fixes #107

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,12 +7,12 @@ var pkg = require('./package.json');
 var jshint    = require('gulp-jshint');
 var uglify    = require('gulp-uglify');
 var webserver = require('gulp-webserver');
-var karma     = require('gulp-karma');
 var concat    = require('gulp-concat');
 var rename    = require('gulp-rename');
 var size      = require('gulp-size');
 var header    = require('gulp-header');
 var rimraf    = require('gulp-rimraf');
+var Server    = require('karma').Server;
 
 var getToday = function() {
 
@@ -85,27 +85,11 @@ gulp.task('build', function() {
 });
 
 //run tests
-gulp.task('karma', function() {
-
-	gulp.src([
-			'node_modules/angular/angular.js',
-			'node_modules/angular-mocks/angular-mocks.js',
-			'bower_components/angular-sanitize/angular-sanitize.js',
-			'node_modules/i18next-client/i18next.min.js',
-			'src/provider.js',
-			'src/{,*/}*.js',
-			'test/polyfills/*.js',
-			'test/{,*/}*Spec.js'
-		])
-		.pipe(karma({
-			configFile: 'karma.conf.js',
-			action: 'run' //Run once
-		}))
-		.on('error', function(err) {
-			// Make sure failed tests cause gulp to exit non-zero
-			throw err;
-		});
-
+gulp.task('karma', function(done) {
+	new Server({
+		configFile: __dirname + '/karma.conf.js',
+		singleRun: true
+	}, done).start();
 });
 
 //TODO: documentation

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,6 +12,17 @@ module.exports = function(config) {
 		// testing framework to use (jasmine/mocha/qunit/...)
 		frameworks: ['jasmine'],
 
+		files: [
+			'node_modules/angular/angular.js',
+			'node_modules/angular-mocks/angular-mocks.js',
+			'bower_components/angular-sanitize/angular-sanitize.js',
+			'node_modules/i18next-client/i18next.min.js',
+			'src/provider.js',
+			'src/{,*/}*.js',
+			'test/polyfills/*.js',
+			'test/{,*/}*Spec.js'
+		],
+
 		// list of files to exclude
 		exclude: [],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "gulp-header": "^1.0.5",
     "gulp-jasmine": "^0.2.0",
     "gulp-jshint": "^1.7.1",
-    "gulp-karma": "0.0.4",
     "gulp-rename": "^1.2.0",
     "gulp-rimraf": "^0.1.0",
     "gulp-size": "^0.4.0",


### PR DESCRIPTION
Dropped the `gulp-karma` plugin for using Karma directly. This removes the dependency issue that was causing builds to fail.