### PR TITLE
Allow specification of the i18next instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Make sure you require `jm.i18next` as a dependency of your AngularJS module. Als
 
 ```js
 angular.module('jm.i18next').config(['$i18nextProvider', function ($i18nextProvider) {
+	// Optionally specify the instance of i18next to use; otherwise, it's obtained from `window`
+	$i18nextProvider.i18next = require('i18next');
+
 	$i18nextProvider.options = {
 		lng: 'de',
 		useCookie: false,
@@ -237,6 +240,18 @@ $i18nextProvider.options = {
 
 => displays "Loading..." until i18next is loaded, then translates `not-translated-welcome-key` with default of "Welcome!"
 if the key is not defined in your i18n file
+
+# Specifying an i18next instance #
+
+`ng-i18next` has an `i18next` property that can be provided to specify the instance of i18next to use. This is particularly useful when i18next is included through a module loader and hasn't been added to `window`.
+
+## i18next instance - Examples ##
+```js
+$i18nextProvider.i18next = require('i18next')
+$i18nextProvider.options = {
+	/* ... */
+};
+```
 
 ---------
 

--- a/src/provider.js
+++ b/src/provider.js
@@ -24,7 +24,7 @@ angular.module('jm.i18next').provider('$i18next', function () {
 				window.i18n.noConflict();
 			}
 
-			var i18n = window.i18next || window.i18n;
+			var i18n = self.i18next || window.i18next || window.i18n;
 
 			if (i18n) {
 


### PR DESCRIPTION
For applications using a module loader, `i18next` will not be put on the `window`, which makes it so that $i18nextProvider can't find `window.i18n` or `window.i18next`. To facilitate this, I updated the provider to look for the `i18next` property on itself. This will allow users to configure the instance of i18next to use when it has been included with a module loader.