### PR TITLE
Fix i18next's major version to 1.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "angular": ">=1.2",
     "angular-sanitize": ">=1.2",
-    "i18next": ">=1.10.0"
+    "i18next": "^1.10.0"
   },
   "devDependencies": {
     "angular-mocks": ">=1.2.20"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "peerDependencies": {
     "angular": ">=1.2",
-    "i18next-client": ">=1.10.0"
+    "i18next-client": "^1.10.0"
   },
   "devDependencies": {
     "angular": ">=1.2",
@@ -28,7 +28,7 @@
     "gulp-size": "^0.4.0",
     "gulp-uglify": "^0.3.1",
     "gulp-webserver": "^0.4.0",
-    "i18next-client": ">=1.10.0",
+    "i18next-client": "^1.10.0",
     "jasmine-core": "^2.4.1",
     "jshint-stylish": ">=1.0.0",
     "karma": ">=0.12.31",


### PR DESCRIPTION
Because ng-i18next 0.5.x doesn't support i18next 2.x.
I would appreciate a release of v0.5.3.