### PR TITLE
#122: Watch the fully-parsed options and call render with the right thisObj

### DIFF
--- a/src/directiveController.ts
+++ b/src/directiveController.ts
@@ -51,8 +51,8 @@ export class I18nDirectiveController implements Ii18nDirectiveController {
 
         if (!noWatch) {
             this.argsUnregister = this.$scope.$watch(() => {
-                return parsedKey.i18nOptions;
-            }, this.render, true);
+                return parsedKey.i18nOptions(this.$scope);
+            }, () => this.render(parsedKey, noWatch), true);
         }
 
         this.render(parsedKey, noWatch);

--- a/test/unit/i18nextDirectiveSpec.js
+++ b/test/unit/i18nextDirectiveSpec.js
@@ -110,6 +110,23 @@ describe('Unit: jm.i18next - Directive', function () {
 			expect(c.text()).toEqual('Herzlich Willkommen, Andre!');
 		});
 
+		it('should replace "{{name}}" in the translation string with scope variable', function () {
+			$rootScope.name = "Wax";
+			var c = $compile('<p ng-i18next="[i18next]({name: name})helloName"></p>')($rootScope);
+			$rootScope.$apply();
+			expect(c.text()).toEqual('Herzlich Willkommen, Wax!');
+		});
+
+		it('should update "{{name}}" in the translation string when scope variable changes', function () {
+			$rootScope.name = "Wax";
+			var c = $compile('<p ng-i18next="[i18next]({name: name})helloName"></p>')($rootScope);
+			$rootScope.$apply();
+			expect(c.text()).toEqual('Herzlich Willkommen, Wax!');
+			$rootScope.name = "Wayne";
+			$rootScope.$apply();
+			expect(c.text()).toEqual('Herzlich Willkommen, Wayne!');
+		});
+
 		it('should replace "{{name}}" in the translation string with name given by options and should use "dev" as language', function () {
 			var c = $compile('<p ng-i18next="[i18next]({name:\'Andre\',lng:\'dev\'})helloName"></p>')($rootScope);
 			$rootScope.$apply();


### PR DESCRIPTION
This fixes #122, which I opened just recently. At the time I wrote the bug report I knew something needed to change with how `this.render` was being used as the callback for the `$watch` expression, but hadn't yet finished going down that path.