### PR TITLE
Check that i18nOptions is defined before using

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,10 +70,12 @@ gulp.task('rollup', ['clean', 'karma'], function () {
 	return gulp.src(['./src/*.ts'])
 		.pipe(rollup({
 			allowRealFiles: true,
-			entry: 'src/provider.ts',
-			format: 'umd',
-			moduleName: 'ngI18next',
-			dest: 'dist/ng-i18next.js',
+			input: 'src/provider.ts',
+			output: {
+				format: 'umd',
+				name: 'ngI18next',
+				file: 'dist/ng-i18next.js'
+			},
 			external: [
 				'typescript'
 			],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function (config) {
 		],
 
 		preprocessors: {
-            './**/!(*spec).ts': ['karma-typescript', 'coverage'],
+			'./**/!(*spec).ts': ['karma-typescript', 'coverage'],
 			'./*.spec.ts': ['karma-typescript']
 		},
 

--- a/src/directiveController.ts
+++ b/src/directiveController.ts
@@ -80,7 +80,7 @@ export class I18nDirectiveController implements Ii18nDirectiveController {
             i18nOptions = tmp.join(')').substr(1).trim();
         }
 
-        let parsedKey: IParsedKey  = {
+        let parsedKey: IParsedKey = {
             i18nOptions: this.$parse(i18nOptions),
             key: key,
             options: options,
@@ -108,15 +108,15 @@ export class I18nDirectiveController implements Ii18nDirectiveController {
         return res;
     }
 
-    private render(parsedKey: any, noWatch: boolean) {
+    private render(parsedKey: IParsedKey, noWatch: boolean) {
         if (angular.isDefined(this) && angular.isDefined(this.$scope)) {
             let i18nOptions = parsedKey.i18nOptions(this.$scope);
 
-            if (i18nOptions.sprintf) {
+            if (angular.isDefined(i18nOptions) && i18nOptions.sprintf) {
                 i18nOptions.postProcess = 'sprintf';
             }
 
-            if (parsedKey.options.attr === 'html') {
+            if (angular.isDefined(i18nOptions) && parsedKey.options.attr === 'html') {
                 angular.forEach(i18nOptions, function (value, key) {
                     let newValue: any = undefined;
                     let sanitized = this.$sanitize(value);


### PR DESCRIPTION
with some expressions `parsedKey.i18nOptions(this.$scope)` returns null in initial digest iterations and that sometimes leads to digest iterations count overflow and consequent faulty states